### PR TITLE
More clear instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ Need to install:
 ```
 cmake
 ninja
-```
-
-Also you can install:
-```
 gcc
 g++
 clang

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you install all these dependencies, you can run:
 ./script/run.sh --proc="Your proc name without space"
 ```
 
+At this point, new benchmark results will be in `:/future/result/<Your proc name without space>`
+
 Then commit and make PR, thanks!
 
 <details>


### PR DESCRIPTION
Previously, user might erroneously think he doesn't need to install gcc, g++ and clang, but that's not true. For clarity sake, I have merged these into a single category "Need to install".

I have also pointed out what happens after `./script/run.sh`, so users know what to expect.